### PR TITLE
bootstrap: restore Rectangle keybindings on fresh macOS install

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ If that fails (network restrictions), ruff still works without node.
    CLI, installed by bootstrap). If any are missing, run `:TSUpdate` or `:TSInstall python`.
 
 
+## Rectangle (macOS window manager)
+
+`bootstrap-mac.sh` installs Rectangle and deploys a fixed set of window-snapping shortcuts
+(halves, corners, maximise, next/previous display), optimized for the Kinesis Advantage 2
+keyboard layout. The bootstrap wipes Rectangle's prefs domain first, so only these shortcuts
+are bound — all other Rectangle actions stay unbound.
+
+To change them: edit a binding in Rectangle's Settings, then read the new value with
+`defaults read com.knollsoft.Rectangle <action>` and update the matching line in `bootstrap-mac.sh`.
+
 ## Known issues
 
 - Resize bug in iTerm 2 with powerline10k: while resizing with the mouse, the prompt gets redrawn multiple times.

--- a/bootstrap-mac.sh
+++ b/bootstrap-mac.sh
@@ -103,6 +103,31 @@ fi
 # Enable repeating keys (disable the popup to select diacritics etc):
 defaults write -g ApplePressAndHoldEnabled -bool false
 
+# Rectangle: deploy custom window-snapping shortcuts (tuned for Kinesis Advantage 2 layout).
+# Quit first (Rectangle rewrites its prefs on exit), wipe the domain so ONLY these
+# shortcuts are bound (no stock defaults linger), write our set, then relaunch.
+echo -e "\nConfiguring Rectangle shortcuts..."
+osascript -e 'quit app "Rectangle"' 2>/dev/null || true
+defaults delete com.knollsoft.Rectangle 2>/dev/null || true
+
+defaults write com.knollsoft.Rectangle leftHalf        '{ keyCode = 123; modifierFlags = 1310720; }'
+defaults write com.knollsoft.Rectangle rightHalf       '{ keyCode = 124; modifierFlags = 1310720; }'
+defaults write com.knollsoft.Rectangle topHalf         '{ keyCode = 126; modifierFlags = 1572864; }'
+defaults write com.knollsoft.Rectangle bottomHalf      '{ keyCode = 125; modifierFlags = 1572864; }'
+defaults write com.knollsoft.Rectangle topLeft         '{ keyCode = 18;  modifierFlags = 1310720; }'
+defaults write com.knollsoft.Rectangle topRight        '{ keyCode = 19;  modifierFlags = 1310720; }'
+defaults write com.knollsoft.Rectangle bottomLeft      '{ keyCode = 20;  modifierFlags = 1310720; }'
+defaults write com.knollsoft.Rectangle bottomRight     '{ keyCode = 21;  modifierFlags = 1310720; }'
+defaults write com.knollsoft.Rectangle maximize        '{ keyCode = 42;  modifierFlags = 1572864; }'
+defaults write com.knollsoft.Rectangle nextDisplay     '{ keyCode = 45;  modifierFlags = 1572864; }'
+defaults write com.knollsoft.Rectangle previousDisplay '{ keyCode = 35;  modifierFlags = 1572864; }'
+
+# Mark config as established so Rectangle does not re-add its built-in default shortcuts.
+defaults write com.knollsoft.Rectangle alternateDefaultShortcuts -int 1
+defaults write com.knollsoft.Rectangle subsequentExecutionMode  -int 1
+
+open -a Rectangle
+
 echo -e "\nAll done!"
 echo "If this is the first time installing powerline10k, run 'p10k configure' to install Meslo Nerd font."
 echo -e "You will also have to reboot to enable repeating keys.\n\nRunning zsh now..."


### PR DESCRIPTION
## Summary

- Adds a Rectangle config block to `bootstrap-mac.sh` that wipes the prefs domain and writes exactly the 11 custom shortcuts (halves, corners, maximise, next/previous display)
- Shortcuts are tuned for the Kinesis Advantage 2 keyboard layout
- `defaults delete` first guarantees no stock Rectangle defaults linger on other actions — only the explicit 11 are bound
- Rectangle is quit before writing and relaunched after (it overwrites prefs on exit)
- Adds a `## Rectangle` section to `README.md` documenting the approach and how to update shortcuts

## Test plan

- [ ] Run `./bootstrap-mac.sh` (or the Rectangle block in isolation)
- [ ] `defaults read com.knollsoft.Rectangle` — only 11 shortcut dicts + 2 flags present, no thirds/quarters/move keys
- [ ] Rectangle → Settings → Shortcuts — bound 11 match, everything else shows "Record Shortcut"
- [ ] Smoke-test one binding (e.g. ^⌘← snaps window to left half)