### PR TITLE
Build Python 3.14.6 with PGO/LTO and native arch tuning

### DIFF
--- a/bootstrap-common.sh
+++ b/bootstrap-common.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -eu
 
-export PY3_VERSION="3.13.0"
+export PY3_VERSION="3.14.6"
+
+# Build CPython optimized for this machine (PGO + LTO + native arch).
+# Note: -march=native produces a non-portable binary, fine for a personal machine.
+export PYTHON_CONFIGURE_OPTS='--enable-optimizations --with-lto' PYTHON_CFLAGS='-march=native -mtune=native'
+export PROFILE_TASK='-m test.regrtest --pgo -j0'
 TS=$(date +'%Y-%m-%dT%H-%M-%S')
 export TS

--- a/bootstrap-mac.sh
+++ b/bootstrap-mac.sh
@@ -47,7 +47,7 @@ else
     echo "pyenv seems to be installed"
 fi
 
-PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install -s "${PY3_VERSION}"
+pyenv install -s "${PY3_VERSION}"
 pyenv global "${PY3_VERSION}"
 pip install --upgrade pip
 pip install --upgrade pipx


### PR DESCRIPTION
Bumps `PY3_VERSION` 3.13.0 -> 3.14.6 and switches the pyenv build to an optimized config.

## Changes
- `bootstrap-common.sh`: bump version; add shared `PYTHON_CONFIGURE_OPTS='--enable-optimizations --with-lto'`, `PYTHON_CFLAGS='-march=native -mtune=native'`, `PROFILE_TASK='-m test.regrtest --pgo -j0'`.
- `bootstrap-mac.sh`: drop `--enable-framework` (only needed for the now-removed Vim YouCompleteMe setup).

## Notes
- `-march=native` -> non-portable binary, fine for personal machines.
- PGO+LTO build is slower (~10-20 min vs ~2 min) but yields a faster interpreter.
- CI does not exercise this path: the Docker build passes `--build-arg SKIP_PYENV=1`, so Ubuntu takes the apt fallback and never runs the pyenv build. CI here only confirms the scripts still build green.