### PR TITLE
Add bat to bootstrap scripts

### DIFF
--- a/bootstrap-mac.sh
+++ b/bootstrap-mac.sh
@@ -34,7 +34,8 @@ brew install \
     fd `# nvim: required by telescope find_files` \
     node `# nvim: required by Mason for basedpyright/jsonls/yamlls LSP servers` \
     tree-sitter-cli `# nvim: required by nvim-treesitter (main branch) to build parsers` \
-    coreutils `# nvim: provides timeout, used during plugin presync`
+    coreutils `# nvim: provides timeout, used during plugin presync` \
+    bat `# cat with syntax highlighting and git integration`
 brew install --cask \
     font-jetbrains-mono-nerd-font `# nvim: full Nerd Font glyph range for nvim-web-devicons; MesloLGS NF (p10k font) only covers p10k glyphs and relies on macOS font fallback for the rest`
 

--- a/bootstrap-ubuntu.sh
+++ b/bootstrap-ubuntu.sh
@@ -16,7 +16,8 @@ sudo apt install --yes \
     xz-utils `# nvim: needed to extract neovim tarball` \
     ripgrep `# nvim: required by telescope live_grep` \
     fd-find `# nvim: required by telescope find_files (binary name: fdfind)` \
-    ncdu `# ncurses du (find big files/dirs fast)`
+    ncdu `# ncurses du (find big files/dirs fast)` \
+    bat `# cat with syntax highlighting (binary name: batcat on Debian/Ubuntu)`
 
 # Neovim: apt version is too old on Ubuntu 24.04 / Debian 12; install from GitHub release.
 NVIM_VERSION="0.12.2"
@@ -113,6 +114,12 @@ fi
 if command -v fdfind > /dev/null && ! command -v fd > /dev/null; then
     mkdir -p "${HOME}/.local/bin"
     ln -sf "$(command -v fdfind)" "${HOME}/.local/bin/fd"
+fi
+
+# bat installs as 'batcat' on Debian/Ubuntu; create 'bat' symlink for consistency with mac.
+if command -v batcat > /dev/null && ! command -v bat > /dev/null; then
+    mkdir -p "${HOME}/.local/bin"
+    ln -sf "$(command -v batcat)" "${HOME}/.local/bin/bat"
 fi
 
 # Node: required by Mason for basedpyright, jsonls, yamlls LSP servers.


### PR DESCRIPTION
## Summary

- Adds `bat` (syntax-highlighting `cat`) to Mac via brew
- Adds `bat` package to Ubuntu/Debian apt install
- Creates `~/.local/bin/bat → batcat` symlink on Ubuntu/Debian for consistent `bat` command across envs (mirrors the `fd`/`fdfind` pattern)